### PR TITLE
Fix : process d'inscription

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/assmat/handler/InscriptionAssmatHandler.java
+++ b/WEB-INF/classes/fr/cg44/plugin/assmat/handler/InscriptionAssmatHandler.java
@@ -943,11 +943,11 @@ public AssmatSolis getAssmat() {
     sb.append(getHiddenFieldTag("formStep", formStep));
     sb.append(getHiddenFieldTag("inscriptionOK", inscriptionOK));
     if (formStep >= IDENTIFICATION_STEP) {
-      sb.append(getHiddenFieldTag("nbTentativeErrone", nbTentativeErrone));
-      sb.append(getHiddenFieldTag("idInscriptionAM", idInscriptionAM));
-      sb.append(getHiddenFieldTag("numeroAgrement", numeroAgrementInteger));
       sb.append(getHiddenFieldTag("commune", commune));
       sb.append(getHiddenFieldTag("communeMam", communeMam));
+      sb.append(getHiddenFieldTag("idInscriptionAM", idInscriptionAM));
+      sb.append(getHiddenFieldTag("nbTentativeErrone", nbTentativeErrone));
+      sb.append(getHiddenFieldTag("numeroAgrement", numeroAgrementInteger));
 
       if(nbTentativeErrone>=NB_TENTATIVE_MAX){	// Formulaire de 2e erreur d'identification
 	      sb.append(getHiddenFieldTag("nom", nom));
@@ -955,18 +955,14 @@ public AssmatSolis getAssmat() {
       }
     }
     if (formStep >= VERIFICATION_STEP) {
-      sb.append(getHiddenFieldTag("nom", nom));
       sb.append(getHiddenFieldTag("civilite", civilite));
+      sb.append(getHiddenFieldTag("nom", nom));
       sb.append(getHiddenFieldTag("prenom", prenom));
-      sb.append(getHiddenFieldTag("dateDeNaissance", dateDeNaissance));
       sb.append(getHiddenFieldTag("email", email));
+      sb.append(getHiddenFieldTag("dateDeNaissance", dateDeNaissance));
       sb.append(getHiddenFieldTag("telephone", telephone));
       sb.append(getHiddenFieldTag("telephoneFixe", telephoneFixe));
       sb.append(getHiddenFieldTag("numeroAgrement", numeroAgrementInteger));
-      
-      sb.append(getHiddenFieldTag("commune", commune));
-      sb.append(getHiddenFieldTag("communeMam", communeMam));
-      sb.append(getHiddenFieldTag("nbTentativeErrone", nbTentativeErrone));
       
       sb.append(getHiddenFieldTag("datePremierAgrement", datePremierAgrement));
       

--- a/plugins/AssmatPlugin/jsp/inscription/contacts.jspf
+++ b/plugins/AssmatPlugin/jsp/inscription/contacts.jspf
@@ -92,7 +92,7 @@ if (step == InscriptionAssmatHandler.CONTACT_STEP) {
 		        </p>
 		        <div class="ds44-posRel">
 		            <label for="form-element-<%= uuid %>" class="ds44-formLabel"><span class="ds44-labelTypePlaceholder"><span><%= glp("jcmsplugin.assmatplugin.inscription.champ.lbl.email") %></span></span></label>
-		            <input type="email" id="form-element-<%= uuid %>" name="email" value="<%=emailAssmat %>" class="ds44-inpStd" title='<%= glp("jcmsplugin.assmatplugin.inscription.champ.lbl.email") %>' autocomplete="email" aria-describedby="explanation-form-element-<%= uuid %>" data-bkp-aria-describedby="explanation-form-element-<%= uuid %>">
+		            <input type="email" id="form-element-<%= uuid %>" name="emailModifiable" value="<%=emailAssmat %>" class="ds44-inpStd" title='<%= glp("jcmsplugin.assmatplugin.inscription.champ.lbl.email") %>' autocomplete="email" aria-describedby="explanation-form-element-<%= uuid %>" data-bkp-aria-describedby="explanation-form-element-<%= uuid %>">
 		            <button class="ds44-reset" type="button"><i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", glp("jcmsplugin.assmatplugin.inscription.champ.lbl.email")) %></span></button>
 		        </div>
 		        <div class="ds44-field-information" aria-live="polite">
@@ -125,7 +125,7 @@ if (step == InscriptionAssmatHandler.CONTACT_STEP) {
 		        </p>
 		        <div class="ds44-posRel">
 		            <label for="form-element-<%= uuid %>" class="ds44-formLabel"><span class="ds44-labelTypePlaceholder"><span><%= glp("jcmsplugin.assmatplugin.inscription.champ.lbl.mobile") %><sup aria-hidden="true">*</sup></span></span></label>
-		            <input type="text" id="form-element-<%= uuid %>" name="telephone" value="<%=telAssmat %>" class="ds44-inpStd" title='<%= glp("jcmsplugin.assmatplugin.inscription.champ.lbl.mobile") %>' autocomplete="tel-national" aria-describedby="explanation-form-element-<%= uuid %>" data-bkp-aria-describedby="explanation-form-element-<%= uuid %>">
+		            <input type="text" id="form-element-<%= uuid %>" name="telephoneModifiable" value="<%=telAssmat %>" class="ds44-inpStd" title='<%= glp("jcmsplugin.assmatplugin.inscription.champ.lbl.mobile") %>' autocomplete="tel-national" aria-describedby="explanation-form-element-<%= uuid %>" data-bkp-aria-describedby="explanation-form-element-<%= uuid %>">
 		            <button class="ds44-reset" type="button"><i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", glp("jcmsplugin.assmatplugin.inscription.champ.lbl.mobile")) %></span></button>
 		        </div>
 		        <div class="ds44-field-information" aria-live="polite">
@@ -156,6 +156,7 @@ if (step == InscriptionAssmatHandler.CONTACT_STEP) {
 	        <div class="ds44-form__container">
 	            <button class="ds44-btnStd" data-submit-value="true" data-submit-key="opPrevious" title='<%= glp("jcmsplugin.assmatplugin.btn.etapeprecedente")%>'><%= glp("jcmsplugin.assmatplugin.btn.etapeprecedente")%></button>
 	            <button class="ds44-btnStd" data-submit-value="true" data-submit-key="opNext" title='<%= glp("jcmsplugin.assmatplugin.btn.etapesuivante")%>'><%= glp("jcmsplugin.assmatplugin.btn.etapesuivante")%></button>
+	            <input type="submit" name="opCreate" class="ds44-btnStd" value='<%= glp("jcmsplugin.assmatplugin.btn.etapesuivante")%>' data-technical-field>
                 <input type="hidden" name="noSendRedirect" value="true" data-technical-field> 
                 <input type="hidden" name="id" value="c_5065" data-technical-field>
             </div>

--- a/plugins/AssmatPlugin/jsp/inscription/identification.jspf
+++ b/plugins/AssmatPlugin/jsp/inscription/identification.jspf
@@ -206,10 +206,9 @@ if (step == InscriptionAssmatHandler.IDENTIFICATION_STEP) {
     <trsb:glp key="CONTACT-SUPPORT-TEL-HTML"></trsb:glp>
     
     <div class="ds44-form__container">
-	    <input type="submit" name="opCreate" class="ds44-btnStd" value='<%= glp("jcmsplugin.assmatplugin.btn.etapesuivante")%>' data-technical-field>
+	    <input type="submit" name="opContact" class="ds44-btnStd" value='<%= glp("jcmsplugin.assmatplugin.btn.etapesuivante")%>' data-submit-key="opContact" data-submit-value="true" data-technical-field>
 	    <input type="hidden" name="noSendRedirect" value="true" data-technical-field>
 	    <input type="hidden" name="id" value="c_5065" data-technical-field>
-	    <input type="hidden" name="opContact" value="true" data-technical-field>
     </div>
 	
 	<%} %>

--- a/plugins/AssmatPlugin/jsp/inscription/inscription.jsp
+++ b/plugins/AssmatPlugin/jsp/inscription/inscription.jsp
@@ -10,6 +10,8 @@ PortletJsp box = (PortletJsp) portlet;
 /* Lors de la soumission du formulaire, c'est la valeur de la case à cocher qui est renvoyée (fieldValue[0])
    quand on revient sur une page précédente ou sur une page suivante, c'est la valeur du champ caché qui en renvoyé (fieldValue)
    On doit donc tester la valeur de ces 2 paramètres.
+   On doit aussi regarder si le tél/email ont été modifiés. On doit donc tester la valeur des champs cachés
+   du formulaire et des champs visibles.
    
 */
 String civiliteParam = null;
@@ -111,7 +113,7 @@ boolean notfoundCompte= false;
 
 								<%@ include file='/plugins/SoclePlugin/jsp/doMessageBoxCustom.jspf' %>
 								<p><%= glp("jcmsplugin.socle.facette.champs-obligatoires") %></p>
-								<!-- TEST -->
+
 								<form method="post"
 									action="<%= ServletUtil.getResourcePath(request) %>"
 									name="formContact" id="formContact" data-no-encoding="true">

--- a/plugins/AssmatPlugin/jsp/inscription/inscription.jsp
+++ b/plugins/AssmatPlugin/jsp/inscription/inscription.jsp
@@ -8,12 +8,27 @@
 PortletJsp box = (PortletJsp) portlet;
 
 /* Lors de la soumission du formulaire, c'est la valeur de la case à cocher qui est renvoyée (fieldValue[0])
-   quand on revient sur une page précédente ou sur une page suivante, c'est la valeur du champ caché qui en renvoyé (filedValue)
-   On doit donc tester la valeur de ces 2 paramètres
+   quand on revient sur une page précédente ou sur une page suivante, c'est la valeur du champ caché qui en renvoyé (fieldValue)
+   On doit donc tester la valeur de ces 2 paramètres.
+   
 */
 String civiliteParam = null;
 String typeEnvoiParam = null;
 String choixLoginParam = null;
+String emailParam = null;
+String telephoneParam = null;
+
+if(Util.notEmpty(request.getParameter("emailModifiable"))){
+  emailParam = request.getParameter("emailModifiable");
+}else if(Util.notEmpty(request.getParameter("email"))){
+  emailParam = request.getParameter("email");
+}
+
+if(Util.notEmpty(request.getParameter("telephoneModifiable"))){
+  telephoneParam = request.getParameter("telephoneModifiable");
+}else if(Util.notEmpty(request.getParameter("telephone"))){
+  telephoneParam = request.getParameter("telephone");
+}
 
 if(Util.notEmpty(request.getParameter("civilite[0]"))){
   civiliteParam = request.getParameter("civilite[0]");
@@ -43,6 +58,8 @@ if(Util.notEmpty(request.getParameter("choixLogin[0]"))){
 	<jsp:setProperty name='formHandler' property="civilite" value='<%= civiliteParam %>' />
 	<jsp:setProperty name='formHandler' property="typeenvoi" value='<%= typeEnvoiParam %>' />
 	<jsp:setProperty name='formHandler' property="choixLogin" value='<%= choixLoginParam %>' />
+	<jsp:setProperty name='formHandler' property="email" value='<%= emailParam %>' />
+	<jsp:setProperty name='formHandler' property="telephone" value='<%= telephoneParam %>' />
 </jsp:useBean>
 
 
@@ -94,6 +111,7 @@ boolean notfoundCompte= false;
 
 								<%@ include file='/plugins/SoclePlugin/jsp/doMessageBoxCustom.jspf' %>
 								<p><%= glp("jcmsplugin.socle.facette.champs-obligatoires") %></p>
+								<!-- TEST -->
 								<form method="post"
 									action="<%= ServletUtil.getResourcePath(request) %>"
 									name="formContact" id="formContact" data-no-encoding="true">

--- a/plugins/AssmatPlugin/jsp/inscription/verification.jspf
+++ b/plugins/AssmatPlugin/jsp/inscription/verification.jspf
@@ -347,9 +347,8 @@ if(Util.notEmpty(assMat.getExerceMam())){
 	</div>
 	
 	<div class="ds44-form__container">
-	    <input type="submit" name="opCreate" class="ds44-btnStd" value='<%= glp("jcmsplugin.assmatplugin.btn.valider")%>' data-technical-field>
+	    <input type="submit" name="opContact" class="ds44-btnStd" value='<%= glp("jcmsplugin.assmatplugin.btn.valider")%>' data-submit-key="opContact" data-submit-value="true" data-technical-field>
 	    <input type="hidden" name="noSendRedirect" value="true" data-technical-field>
-	    <input type="hidden" id="inputContact" name="opContact" value="true" data-technical-field>
     </div>
               
 
@@ -376,17 +375,7 @@ if(Util.notEmpty(assMat.getExerceMam())){
 			<p><trsb:glp key="LIBELLE-TEL-UNITE-AGREMENT-HTML" parameter="<%=tabParam %>"></trsb:glp></p>
 		</div>
     <%} %>
-	<%--   
-        <p class="submit">
-             
-               <label for="submit"> <input type="submit" id="submit"
-                 name="opCreate" value="Etape suivante" class="submitButton">
-                 <span class="input-box" style="background-color: #aec900"><span
-                   class="spr-recherche-ok"></span></span>
-               </label> <input type="hidden" name="noSendRedirect" value="true">
-              <input type="hidden" name="opNext" value="true">
-             </p>
-	 --%>
+
 </div>		
 
 <%-- FIN FORMULAIRE A ETAPES --%>


### PR DESCRIPTION
- modification de la gestion du mail et tel qui sont modifiables par l'AM. Ne fonctionnait plus car les input text et hidden avaient le même nom et c'est la valeur du hidden qui était renvoyée systématiquement.
- modification de la gestion des envois de mail en cas de pb d'activation ou de signalement d'erreur. On teste la valeur du submit et plus du champ caché car celui-ci étant envoyé systématiquement, le mail était envoyé plusieurs fois en cas de retour arrière dans les étapes du formulaire.