### PR TITLE
Fix : portails assmats

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/assmat/policyfilter/AssmatPortalPolicyFilter.java
+++ b/WEB-INF/classes/fr/cg44/plugin/assmat/policyfilter/AssmatPortalPolicyFilter.java
@@ -57,11 +57,11 @@ public class AssmatPortalPolicyFilter extends BasicPortalPolicyFilter {
 	
 			ProfilASSMAT profil = ProfilManager.getInstance().getProfilASSMAT(mbr);
 	
-			String idPortalAccueil = channel.getProperty("jcmsplugin.assmatplugin.general.portal.accueil");
 			String idPortal1colonne = channel.getProperty("jcmsplugin.assmatplugin.socle.portal.colonne");
+			
 			if (Util.notEmpty(profil)) {
 				// On redirige vers le portail 1 colonne (gestion du profil)
-				portal = (PortalInterface) channel.getData(idPortalAccueil);
+				portal = (PortalInterface) channel.getData(idPortal1colonne);
 			} 
 			// Le membre n'as pas de profil, on le redirige vers l'accueil
 		

--- a/WEB-INF/plugins/AssmatPlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/AssmatPlugin/properties/plugin.prop
@@ -40,7 +40,7 @@ jcmsplugin.assmatplugin.socle.confirm.catLoginRedirect: mfo_60353
 jcmsplugin.assmatplugin.socle.categ.accueil.perso: cra_60267
 
 # ID du portail accueil Espace Perso
-jcmsplugin.assmatplugin.socle.portail.param.id:cra_60294
+jcmsplugin.assmatplugin.socle.portail.param.id:cra_103077
 
 # Remplacement du fichier de Login
 jcms.resource.login: plugins/AssmatPlugin/jsp/loginAM.jsp

--- a/plugins/AssmatPlugin/jsp/loginAM.jsp
+++ b/plugins/AssmatPlugin/jsp/loginAM.jsp
@@ -27,6 +27,11 @@ Category currentCategory = PortalManager.getDisplayContext(channel.getCurrentJcm
 
 String redirectUrl = Util.getString(getValidHttpUrl("redirect"), ServletUtil.getBaseUrl(request) + "index.jsp");
 String redirectAccueilAssmat = Util.notEmpty(request.getParameter("redirectAccueilAssmat")) ? request.getParameter("redirectAccueilAssmat") : "";
+
+Publication portalPerso = channel.getPublication(channel.getProperty("jcmsplugin.assmatplugin.socle.portail.param.id"));
+if (Util.notEmpty(portalPerso)){
+  redirectUrl = portalPerso.getDisplayUrl(userLocale);
+}
 %>
 
 <main role="main" id="content">
@@ -41,7 +46,7 @@ String redirectAccueilAssmat = Util.notEmpty(request.getParameter("redirectAccue
                   <div class="ds44-innerBoxContainer">
                      <div class="grid-12-small-1">
                         <div class="col-5-small-1">
-                           <form novalidate="true" data-is-initialized="true" action="<%= channel.getCategory(channel.getProperty("jcmsplugin.assmatplugin.general.categ.accueil")).getDisplayUrl(userLocale) %>" method="post" name="login">
+                           <form novalidate="true" data-is-initialized="true" action="<%= redirectUrl %>" method="post" name="login">
                               <h2 class="h4-like ds44-mb-std"><%= glp("plugin.assmatplugin.screen.login.alreadyhaveaccount") %></h2>
                               <%= glp("plugin.assmatplugin.screen.login.assistantmaternel.desc.html") %>
                               <div>

--- a/plugins/AssmatPlugin/jsp/parametrage/parametrage.jsp
+++ b/plugins/AssmatPlugin/jsp/parametrage/parametrage.jsp
@@ -83,7 +83,6 @@ int stepCount = formHandler.getFormStepCount();
   String uuid = UUID.randomUUID().toString();
 %>
 
-<main id="content">
 
     <div class="ds44-container-large">
        <div class="ds44-inner-container ds44-mtb5">


### PR DESCRIPTION
- Si profil renseigné, renvoyer vers le portail d'accueil de l'espace perso des assmats, lors d'un retour à la page d'accueil
- Suppression d'un "main" superflu