### PR TITLE
Evol : déconnexion pour les RAM

### DIFF
--- a/plugins/AssmatPlugin/jsp/espaceRAM/monProfilRAM.jsp
+++ b/plugins/AssmatPlugin/jsp/espaceRAM/monProfilRAM.jsp
@@ -100,7 +100,7 @@ if(Util.notEmpty(loggedMember) && (AssmatUtil.isMemberRAM(loggedMember))){
 				</jalios:if>
 				
 				<li><a href="<%=publi.getDisplayUrl(userLocale) %>?portal=<%=idPortalRAM%>"><trsb:glp key="ESPACE-RAM-CHANGE-PASS-MEMBER" ></trsb:glp></a></li>
-				<li><a href="front/logout.jsp"><trsb:glp key="ESPACE-RAM-DECONNEXION-MEMBER" ></trsb:glp></a></li>
+				<li><a href="front/logout.jsp?redirect=<%=HttpUtil.encodeForURL(ServletUtil.getUrl(request))%>"><trsb:glp key="ESPACE-RAM-DECONNEXION-MEMBER" ></trsb:glp></a></li>
 			</ul>
 			
         </div>


### PR DESCRIPTION
Après déconnexion, ne pas repartir sur l'accueil mais rester sur la page courante.